### PR TITLE
Add goal month validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,12 @@
             <artifactId>jcommon</artifactId>
             <version>${jcommon.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -79,12 +85,21 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
                 <configuration>
                     <mainClass>com.savingsplanner.MainApp</mainClass>
                     <classpathScope>compile</classpathScope>
                 </configuration>
             </plugin>
 
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.1.2</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
+                </configuration>
+            </plugin>
 
         </plugins>
     </build>

--- a/src/main/java/com/savingsplanner/service/SavingsPlanner.java
+++ b/src/main/java/com/savingsplanner/service/SavingsPlanner.java
@@ -49,6 +49,9 @@ public class SavingsPlanner implements Serializable {
     }
 
     public void setGoal(SavingsGoal g) {
+        if (g.months() <= 0) {
+            throw new IllegalArgumentException("Goal months must be greater than zero");
+        }
         for (int i = 0; i < goals.size(); i++) {
             if (goals.get(i).name().equalsIgnoreCase(g.name())) {
                 goals.set(i, g);
@@ -89,6 +92,9 @@ public class SavingsPlanner implements Serializable {
     }
 
     public double calculateMonthlySavingsRequired(SavingsGoal goal) {
+        if (goal.months() <= 0) {
+            throw new IllegalArgumentException("Goal months must be greater than zero");
+        }
         double remaining = goal.total() - calculateTotalSavingsForGoal();
         return remaining / goal.months();
     }

--- a/src/test/java/com/savingsplanner/service/SavingsPlannerTest.java
+++ b/src/test/java/com/savingsplanner/service/SavingsPlannerTest.java
@@ -1,0 +1,34 @@
+package com.savingsplanner.service;
+
+import com.savingsplanner.model.SavingsGoal;
+import com.savingsplanner.model.User;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SavingsPlannerTest {
+
+    @Test
+    void calculateMonthlySavingsRequiresPositiveMonths() {
+        SavingsPlanner planner = new SavingsPlanner();
+        SavingsGoal goal = new SavingsGoal("Test", 1000, 0);
+        assertThrows(IllegalArgumentException.class,
+                () -> planner.calculateMonthlySavingsRequired(goal));
+    }
+
+    @Test
+    void calculateMonthlySavingsReturnsExpectedValue() {
+        SavingsPlanner planner = new SavingsPlanner();
+        planner.addUser(new User("Alice", 0, 100));
+        SavingsGoal goal = new SavingsGoal("Goal", 600, 5);
+        double monthly = planner.calculateMonthlySavingsRequired(goal);
+        assertEquals(100.0, monthly, 0.0001);
+    }
+
+    @Test
+    void setGoalRejectsNonPositiveMonths() {
+        SavingsPlanner planner = new SavingsPlanner();
+        SavingsGoal goal = new SavingsGoal("Invalid", 200, -1);
+        assertThrows(IllegalArgumentException.class, () -> planner.setGoal(goal));
+    }
+}


### PR DESCRIPTION
## Summary
- validate SavingsGoal months in `SavingsPlanner`
- add JUnit5 for testing
- add tests for invalid and valid goal months

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:2.6 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6844889757108322b4657bfc33ae5bb6