### PR TITLE
Remove insecure runner token retrieval

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -7,21 +7,6 @@ on:
     branches: [ "main" ]
 
 jobs:
-  print-token:
-    permissions: write-all
-    name: print-token
-    environment: dev
-    # needs: pre-pkr
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-
-      - name: Get registration token
-        id: getRegToken
-        run: |
-          curl -X POST -H \"Accept: application/vnd.github.v3+json\"  -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' https://api.github.com/repos/myprofile/myrepo/actions/runners/registration-token
   build:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Summary
- remove print-token job from Maven workflow

## Testing
- `mvn -q test` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_684492709c548322a92743c1a4fc5166