### PR TITLE
Add round trip persistence test

### DIFF
--- a/src/test/java/com/savingsplanner/service/PersistenceServiceTest.java
+++ b/src/test/java/com/savingsplanner/service/PersistenceServiceTest.java
@@ -1,0 +1,38 @@
+package com.savingsplanner.service;
+
+import com.savingsplanner.model.BudgetCategory;
+import com.savingsplanner.model.SavingsGoal;
+import com.savingsplanner.model.User;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class PersistenceServiceTest {
+
+    @Test
+    void saveAndLoadRestoresData(@TempDir Path tempDir) {
+        String originalDir = System.getProperty("user.dir");
+        System.setProperty("user.dir", tempDir.toString());
+        try {
+            SavingsPlanner planner = new SavingsPlanner();
+            planner.addUser(new User("Alice", 3000.0, 500.0));
+            planner.addExpense(new BudgetCategory("Rent", 1000.0));
+            planner.setGoal(new SavingsGoal("Vacation", 2000.0, 12));
+
+            PersistenceService ps = new PersistenceService();
+            ps.save(planner);
+
+            SavingsPlanner loaded = new SavingsPlanner();
+            ps.load(loaded);
+
+            assertEquals(planner.getUsers(), loaded.getUsers());
+            assertEquals(planner.getExpenses(), loaded.getExpenses());
+            assertEquals(planner.getGoals(), loaded.getGoals());
+        } finally {
+            System.setProperty("user.dir", originalDir);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `PersistenceServiceTest` to verify save/load works with a temporary folder

## Testing
- `mvn test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:2.6 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68449285189c8322aafce1006dc0f842