### PR TITLE
Fix README closing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,5 +88,8 @@ Contributions are welcome! Please follow these guidelines:
 * Avoid inline comments; rely on clear method names.
 * Log errors and key application events for troubleshooting.
 
----
+## License
+
+This project is released under the [MIT License](LICENSE).
+You are free to use, modify, and distribute the code as permitted by the license.
 


### PR DESCRIPTION
## Summary
- add a "License" section to the README for clarity

## Testing
- `mvn -q test` *(fails: maven dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6844926e9eb483228c6262f17dcf8996