### PR TITLE
Add settings dialog and preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A simple Java Swing application for planning and tracking personal savings goals
 * **Savings Calculation**: Determine required monthly contributions to meet each goal.
 * **Visualization**: View a savings trajectory chart implemented with JFreeChart.
 * **Editable Tables**: Modify budget categories and goal parameters through a user-friendly table interface.
-* **Settings**: Configure application preferences, including UI theme (light/dark) and file locations.
+* **Settings**: Configure application preferences, including UI theme (light/dark) and file locations via the **File → Settings** menu.
 * **Persistence**: Save and load user data (goals, budgets, settings) as JSON files using Jackson.
 * **Logging**: Application events and errors are logged via Log4j2 (logs/app.log).
 
@@ -70,7 +70,7 @@ java -jar target/savings-planner-1.0-SNAPSHOT.jar
 
 * **Data File**: Default `savings_data.json` in the project root (or as specified in Settings).
 * **Logs**: Written to `logs/app.log`.
-* **UI Theme**: Toggle between light and dark themes via the Settings dialog.
+* **UI Theme**: Toggle between light and dark themes via the **File → Settings** dialog.
 
 ## Dependencies
 

--- a/src/main/java/com/savingsplanner/MainApp.java
+++ b/src/main/java/com/savingsplanner/MainApp.java
@@ -6,6 +6,7 @@ import com.savingsplanner.model.User;
 import com.savingsplanner.model.SavingsGoal;
 import com.savingsplanner.service.PersistenceService;
 import com.savingsplanner.service.SavingsPlanner;
+import com.savingsplanner.ui.SettingsDialog;
 import com.savingsplanner.ui.UserPanel;
 import com.savingsplanner.ui.ExpensePanel;
 import com.savingsplanner.ui.GoalPanel;
@@ -16,13 +17,32 @@ import lombok.extern.log4j.Log4j2;
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;
 import java.awt.*;
+import java.util.prefs.Preferences;
 
 import static javax.swing.WindowConstants.EXIT_ON_CLOSE;
 
 @Log4j2
 public class MainApp {
+
+    private static final Preferences PREFS = Preferences.userNodeForPackage(MainApp.class);
+
+    public static void applyTheme(boolean dark, JFrame frame) {
+        try {
+            if (dark) {
+                UIManager.setLookAndFeel(new FlatDarkLaf());
+            } else {
+                UIManager.setLookAndFeel(new FlatLightLaf());
+            }
+            SwingUtilities.updateComponentTreeUI(frame);
+            PREFS.putBoolean("darkMode", dark);
+        } catch (Exception ex) {
+            log.error("Failed to apply theme", ex);
+        }
+    }
+
     public static void main(String[] args) {
-        FlatDarkLaf.setup();
+        boolean dark = PREFS.getBoolean("darkMode", true);
+        if (dark) FlatDarkLaf.setup(); else FlatLightLaf.setup();
 
         SwingUtilities.invokeLater(() -> {
             SavingsPlanner planner    = new SavingsPlanner();
@@ -37,24 +57,13 @@ public class MainApp {
             frame.setDefaultCloseOperation(EXIT_ON_CLOSE);
 
             JMenuBar menuBar = new JMenuBar();
-            JMenu view = new JMenu("View");
-            JCheckBoxMenuItem darkModeItem = new JCheckBoxMenuItem("Dark Mode", true);
-            view.add(darkModeItem);
-            menuBar.add(view);
+            JMenu fileMenu = new JMenu("File");
+            JMenuItem settingsItem = new JMenuItem("Settings...");
+            fileMenu.add(settingsItem);
+            menuBar.add(fileMenu);
             frame.setJMenuBar(menuBar);
 
-            darkModeItem.addActionListener(e -> {
-                try {
-                    if (darkModeItem.isSelected()) {
-                        UIManager.setLookAndFeel(new FlatDarkLaf());
-                    } else {
-                        UIManager.setLookAndFeel(new FlatLightLaf());
-                    }
-                    SwingUtilities.updateComponentTreeUI(frame);
-                } catch (Exception ex) {
-                    log.error("Dark mode toggle failed", ex);
-                }
-            });
+            settingsItem.addActionListener(e -> SettingsDialog.showDialog(frame, ps));
 
             JPanel main = new JPanel();
             main.setLayout(new BoxLayout(main, BoxLayout.Y_AXIS));

--- a/src/main/java/com/savingsplanner/service/PersistenceService.java
+++ b/src/main/java/com/savingsplanner/service/PersistenceService.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.savingsplanner.model.persistence.SaveFile;
 import lombok.extern.log4j.Log4j2;
 
+import java.util.prefs.Preferences;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.Serial;
@@ -15,10 +17,22 @@ import java.io.Serializable;
 public class PersistenceService implements Serializable {
     @Serial
     private static final long serialVersionUID = 646463464646L;
-    private final File file = new File("savings_data.json");
+
+    private final Preferences prefs = Preferences.userNodeForPackage(PersistenceService.class);
+    private File file;
+
     private final ObjectMapper mapper = new ObjectMapper()
             .registerModule(new JavaTimeModule())
             .enable(SerializationFeature.INDENT_OUTPUT);
+
+    public PersistenceService() {
+        this.file = new File(prefs.get("dataFilePath", "savings_data.json"));
+    }
+
+    public void setFilePath(String path) {
+        this.file = new File(path);
+        prefs.put("dataFilePath", path);
+    }
 
     public void load(SavingsPlanner planner) {
         if (!file.exists()) return;

--- a/src/main/java/com/savingsplanner/ui/SettingsDialog.java
+++ b/src/main/java/com/savingsplanner/ui/SettingsDialog.java
@@ -1,0 +1,75 @@
+package com.savingsplanner.ui;
+
+import com.savingsplanner.MainApp;
+import com.savingsplanner.service.PersistenceService;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.prefs.Preferences;
+
+public class SettingsDialog extends JDialog {
+    private final JTextField pathField = new JTextField(20);
+    private final JCheckBox darkMode = new JCheckBox("Dark mode");
+    private final Preferences prefs = Preferences.userNodeForPackage(SettingsDialog.class);
+    private final PersistenceService persistence;
+    private final JFrame owner;
+
+    public SettingsDialog(JFrame owner, PersistenceService ps) {
+        super(owner, "Settings", true);
+        this.owner = owner;
+        this.persistence = ps;
+
+        setLayout(new BorderLayout(10, 10));
+        JPanel center = new JPanel();
+        center.setLayout(new BoxLayout(center, BoxLayout.Y_AXIS));
+        center.add(createPathPanel());
+        center.add(Box.createVerticalStrut(10));
+        darkMode.setSelected(prefs.getBoolean("darkMode", true));
+        center.add(darkMode);
+        add(center, BorderLayout.CENTER);
+
+        JPanel buttons = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+        JButton ok = new JButton("OK");
+        JButton cancel = new JButton("Cancel");
+        buttons.add(ok);
+        buttons.add(cancel);
+        add(buttons, BorderLayout.SOUTH);
+
+        ok.addActionListener(e -> applyAndClose());
+        cancel.addActionListener(e -> setVisible(false));
+
+        pack();
+        setLocationRelativeTo(owner);
+    }
+
+    private JPanel createPathPanel() {
+        JPanel panel = new JPanel(new BorderLayout(5, 5));
+        panel.add(new JLabel("Data file:"), BorderLayout.WEST);
+        pathField.setText(prefs.get("dataFilePath", "savings_data.json"));
+        panel.add(pathField, BorderLayout.CENTER);
+        JButton browse = new JButton("Browse...");
+        browse.addActionListener(e -> {
+            JFileChooser fc = new JFileChooser(pathField.getText());
+            int res = fc.showSaveDialog(this);
+            if (res == JFileChooser.APPROVE_OPTION) {
+                pathField.setText(fc.getSelectedFile().getPath());
+            }
+        });
+        panel.add(browse, BorderLayout.EAST);
+        return panel;
+    }
+
+    private void applyAndClose() {
+        String path = pathField.getText().trim();
+        prefs.put("dataFilePath", path);
+        prefs.putBoolean("darkMode", darkMode.isSelected());
+        persistence.setFilePath(path);
+        MainApp.applyTheme(darkMode.isSelected(), owner);
+        setVisible(false);
+    }
+
+    public static void showDialog(JFrame owner, PersistenceService ps) {
+        SettingsDialog dlg = new SettingsDialog(owner, ps);
+        dlg.setVisible(true);
+    }
+}

--- a/src/test/java/com/savingsplanner/service/PersistenceServiceTest.java
+++ b/src/test/java/com/savingsplanner/service/PersistenceServiceTest.java
@@ -6,6 +6,8 @@ import com.savingsplanner.model.User;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.util.prefs.Preferences;
+
 import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -14,8 +16,9 @@ public class PersistenceServiceTest {
 
     @Test
     void saveAndLoadRestoresData(@TempDir Path tempDir) {
-        String originalDir = System.getProperty("user.dir");
-        System.setProperty("user.dir", tempDir.toString());
+        Preferences prefs = Preferences.userNodeForPackage(PersistenceService.class);
+        String path = tempDir.resolve("data.json").toString();
+        prefs.put("dataFilePath", path);
         try {
             SavingsPlanner planner = new SavingsPlanner();
             planner.addUser(new User("Alice", 3000.0, 500.0));
@@ -32,7 +35,7 @@ public class PersistenceServiceTest {
             assertEquals(planner.getExpenses(), loaded.getExpenses());
             assertEquals(planner.getGoals(), loaded.getGoals());
         } finally {
-            System.setProperty("user.dir", originalDir);
+            prefs.remove("dataFilePath");
         }
     }
 }


### PR DESCRIPTION
## Summary
- implement `SettingsDialog` for changing data file path and dark mode
- wire `SettingsDialog` into `MainApp` and update theme handling
- read/write data file preference in `PersistenceService`
- document settings usage in README
- adjust tests for new preferences

## Testing
- `mvn -q test` *(fails: Plugin resolution from Maven Central blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684498bec09c8322b4f2ff4822bd482d