### PR TITLE
Add savings date and 50/30/20 info

### DIFF
--- a/src/main/java/com/savingsplanner/ui/GraphPanel.java
+++ b/src/main/java/com/savingsplanner/ui/GraphPanel.java
@@ -54,28 +54,36 @@ public class GraphPanel extends JPanel {
         double startSaved = planner.calculateTotalSavingsForGoal();
         double suggestedMonthly = planner.calculateSuggestedSavings(goal)[0];
         double maxMonthly = planner.calculateRemainingBalance();
+        double twentyMonthly = planner.calculateTotalIncome() * 0.20;
         double goalTotal = goal.total();
 
         double remainingNeed = Math.max(0, goalTotal - startSaved);
         int monthsMaxNeeded = maxMonthly > 0 ? (int) Math.ceil(remainingNeed / maxMonthly) : 0;
-        int monthsToShow = Math.max(months, monthsMaxNeeded);
+        int monthsTwentyNeeded = twentyMonthly > 0 ? (int) Math.ceil(remainingNeed / twentyMonthly) : 0;
+        int monthsToShow = Math.max(Math.max(months, monthsMaxNeeded), monthsTwentyNeeded);
 
         TimeSeries suggested = new TimeSeries("Suggested Plan");
         TimeSeries accelerated = new TimeSeries("Max Savings Plan");
+        TimeSeries twentySeries = new TimeSeries("20% Income Plan");
 
         YearMonth start = YearMonth.now();
         for (int i = 0; i <= monthsToShow; i++) {
             YearMonth current = start.plusMonths(i);
             double savedSuggested = Math.min(goalTotal, startSaved + i * suggestedMonthly);
             double savedMax = Math.min(goalTotal, startSaved + i * maxMonthly);
+            double savedTwenty = Math.min(goalTotal, startSaved + i * twentyMonthly);
             suggested.add(new Month(current.getMonthValue(), current.getYear()), savedSuggested);
             accelerated.add(new Month(current.getMonthValue(), current.getYear()), savedMax);
+            twentySeries.add(new Month(current.getMonthValue(), current.getYear()), savedTwenty);
         }
 
         TimeSeriesCollection dataset = new TimeSeriesCollection();
         dataset.addSeries(suggested);
         if (maxMonthly > suggestedMonthly && monthsMaxNeeded > 0) {
             dataset.addSeries(accelerated);
+        }
+        if (twentyMonthly > 0) {
+            dataset.addSeries(twentySeries);
         }
         return dataset;
     }

--- a/src/main/java/com/savingsplanner/util/DialogUtil.java
+++ b/src/main/java/com/savingsplanner/util/DialogUtil.java
@@ -99,6 +99,10 @@ public final class DialogUtil {
                 LocalDate fastestDate = today.plusMonths((int) Math.ceil(monthsNeededIfMax));
                 sb.append(String.format("   • Saving your entire remaining balance (£%,.2f) hits £%,.2f on: %s%n",
                         remainingBalance, goalTotal, fastestDate.format(ukFmt)));
+                double monthsAtTwenty = remainingNeed / savings;
+                LocalDate dateAtTwenty = today.plusMonths((int) Math.ceil(monthsAtTwenty));
+                sb.append(String.format("   • Saving the 20%% amount (£%,.2f) hits £%,.2f on: %s%n",
+                        savings, goalTotal, dateAtTwenty.format(ukFmt)));
             } else {
                 sb.append(String.format("→ £%,.2f > £%,.2f, so goal is not achievable.%n%n",
                         requiredMonthly, remainingBalance));
@@ -107,6 +111,10 @@ public final class DialogUtil {
                         goalTotal, remainingBalance, monthsNeededIfMax, monthsToAchieve));
                 sb.append(String.format("   • At £%,.2f/month, you’ll hit £%,.2f on: %s%n",
                         remainingBalance, goalTotal, achievedDate.format(ukFmt)));
+                double monthsAtTwenty = remainingNeed / savings;
+                LocalDate dateAtTwenty = today.plusMonths((int) Math.ceil(monthsAtTwenty));
+                sb.append(String.format("   • Saving the 20%% amount (£%,.2f) hits £%,.2f on: %s%n",
+                        savings, goalTotal, dateAtTwenty.format(ukFmt)));
             }
         }
 

--- a/src/main/java/com/savingsplanner/util/DialogUtil.java
+++ b/src/main/java/com/savingsplanner/util/DialogUtil.java
@@ -63,15 +63,23 @@ public final class DialogUtil {
         sb.append(String.format("2) Total expenses (all categories): £%,.2f%n", totalExpenses));
         sb.append(String.format("3) Remaining balance (1 − 2): £%,.2f%n%n", remainingBalance));
 
-        sb.append(String.format("4) Total already saved (all users): £%,.2f%n", totalAlreadySaved));
-        sb.append(String.format("5) Remaining to save (%,.2f − %,.2f): £%,.2f%n",
+        double needs = totalIncome * 0.50;
+        double wants = totalIncome * 0.30;
+        double savings = totalIncome * 0.20;
+        sb.append("4) 50/30/20 rule suggestion:\n");
+        sb.append(String.format("   • Needs (50%%): £%,.2f%n", needs));
+        sb.append(String.format("   • Wants (30%%): £%,.2f%n", wants));
+        sb.append(String.format("   • Savings (20%%): £%,.2f%n%n", savings));
+
+        sb.append(String.format("5) Total already saved (all users): £%,.2f%n", totalAlreadySaved));
+        sb.append(String.format("6) Remaining to save (%,.2f − %,.2f): £%,.2f%n",
                 goalTotal, totalAlreadySaved, remainingNeed));
 
         if (remainingBalance <= 0) {
             sb.append("\n→ Remaining balance is zero or negative. You have no funds available to save toward this goal.\n");
         } else {
             double requiredMonthly = (goalTotal - totalAlreadySaved) / monthsRemaining;
-            sb.append(String.format("6) Monthly savings required (5 ÷ %d): £%,.2f%n%n",
+        sb.append(String.format("7) Monthly savings required (6 ÷ %d): £%,.2f%n%n",
                     monthsRemaining, requiredMonthly));
 
             boolean isAchievable = (requiredMonthly <= remainingBalance);
@@ -88,6 +96,9 @@ public final class DialogUtil {
                 sb.append(String.format("   • You need £%,.2f per month.%n", requiredMonthly));
                 sb.append(String.format("   • If you save £%,.2f each month, you’ll hit £%,.2f on: %s%n",
                         requiredMonthly, goalTotal, achievedDate.format(ukFmt)));
+                LocalDate fastestDate = today.plusMonths((int) Math.ceil(monthsNeededIfMax));
+                sb.append(String.format("   • Saving your entire remaining balance (£%,.2f) hits £%,.2f on: %s%n",
+                        remainingBalance, goalTotal, fastestDate.format(ukFmt)));
             } else {
                 sb.append(String.format("→ £%,.2f > £%,.2f, so goal is not achievable.%n%n",
                         requiredMonthly, remainingBalance));


### PR DESCRIPTION
## Summary
- enhance analysis output with 50/30/20 rule breakdown
- show fastest possible date to reach goal when saving remaining balance

## Testing
- `apt-get update -y`
- `apt-get install -y maven`
- `mvn -q test` *(fails: PluginResolutionException)*


------
https://chatgpt.com/codex/tasks/task_e_68449fedf47483229d31212699bd50e3