### PR TITLE
Fix number parsing in table editors

### DIFF
--- a/src/main/java/com/savingsplanner/ui/ExpensePanel.java
+++ b/src/main/java/com/savingsplanner/ui/ExpensePanel.java
@@ -52,7 +52,7 @@ public class ExpensePanel extends JPanel {
                 Object totObj = table.getValueAt(r, 1);
                 try {
                     String nm    = catObj.toString().trim();
-                    double tot   = ((Number)totObj).doubleValue();
+                    double tot   = parseCell(totObj);
                     planner.updateExpense(r, new BudgetCategory(nm, tot));
                     persistence.save(planner);
                     updateTotalLabel(planner, totalLabel);
@@ -98,6 +98,14 @@ public class ExpensePanel extends JPanel {
         TwoColumnPanel container = new TwoColumnPanel(left, addBtn, removeBtn);
         container.addFooter(totalLabel);
         add(container, BorderLayout.CENTER);
+    }
+
+    private double parseCell(Object value) throws Exception {
+        if (value instanceof Number n) {
+            return n.doubleValue();
+        }
+        NumberFormat fmt = NumberFormat.getCurrencyInstance(Locale.UK);
+        return fmt.parse(value.toString().trim()).doubleValue();
     }
 
     private EditableTablePanel createTablePanel(SavingsPlanner planner) {

--- a/src/main/java/com/savingsplanner/ui/UserPanel.java
+++ b/src/main/java/com/savingsplanner/ui/UserPanel.java
@@ -76,8 +76,8 @@ public class UserPanel extends JPanel {
                 Object savedObj = table.getValueAt(row, 2);
                 try {
                     String nm = nameObj.toString().trim();
-                    double inc = ((Number) incomeObj).doubleValue();
-                    double sav = ((Number) savedObj).doubleValue();
+                    double inc = parseCell(incomeObj, fmt);
+                    double sav = parseCell(savedObj, fmt);
                     planner.updateUser(row, new User(nm, inc, sav));
                     persistence.save(planner);
                     updateTotalLabel(planner, totalLabel);
@@ -127,6 +127,13 @@ public class UserPanel extends JPanel {
         TwoColumnPanel container = new TwoColumnPanel(left, addBtn, removeBtn);
         container.addFooter(totalLabel);
         add(container, BorderLayout.CENTER);
+    }
+
+    private double parseCell(Object value, NumberFormat fmt) throws Exception {
+        if (value instanceof Number n) {
+            return n.doubleValue();
+        }
+        return fmt.parse(value.toString().trim()).doubleValue();
     }
 
     private void updateTotalLabel(SavingsPlanner planner, JLabel lbl) {

--- a/src/main/java/com/savingsplanner/ui/common/NumberEditor.java
+++ b/src/main/java/com/savingsplanner/ui/common/NumberEditor.java
@@ -13,4 +13,14 @@ public class NumberEditor extends DefaultCellEditor {
         ftf.setHorizontalAlignment(SwingConstants.RIGHT);
         ftf.setFocusLostBehavior(JFormattedTextField.COMMIT_OR_REVERT);
     }
+
+    @Override
+    public Object getCellEditorValue() {
+        JFormattedTextField ftf = (JFormattedTextField) getComponent();
+        Object value = ftf.getValue();
+        if (value instanceof Number n) {
+            return n.doubleValue();
+        }
+        return super.getCellEditorValue();
+    }
 }


### PR DESCRIPTION
## Summary
- ensure table cell editor returns numeric values
- parse currency-formatted cells in User and Expense panels

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:2.6 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6844a088d6d0832281bd30fc7e91a62d