### PR TITLE
Fix parsing of plain numeric strings in panels

### DIFF
--- a/src/main/java/com/savingsplanner/ui/ExpensePanel.java
+++ b/src/main/java/com/savingsplanner/ui/ExpensePanel.java
@@ -105,7 +105,12 @@ public class ExpensePanel extends JPanel {
             return n.doubleValue();
         }
         NumberFormat fmt = NumberFormat.getCurrencyInstance(Locale.UK);
-        return fmt.parse(value.toString().trim()).doubleValue();
+        String txt = value.toString().trim();
+        try {
+            return fmt.parse(txt).doubleValue();
+        } catch (Exception ex) {
+            return Double.parseDouble(txt.replaceAll("[^0-9.\-]", ""));
+        }
     }
 
     private EditableTablePanel createTablePanel(SavingsPlanner planner) {

--- a/src/main/java/com/savingsplanner/ui/UserPanel.java
+++ b/src/main/java/com/savingsplanner/ui/UserPanel.java
@@ -133,7 +133,12 @@ public class UserPanel extends JPanel {
         if (value instanceof Number n) {
             return n.doubleValue();
         }
-        return fmt.parse(value.toString().trim()).doubleValue();
+        String txt = value.toString().trim();
+        try {
+            return fmt.parse(txt).doubleValue();
+        } catch (Exception ex) {
+            return Double.parseDouble(txt.replaceAll("[^0-9.\-]", ""));
+        }
     }
 
     private void updateTotalLabel(SavingsPlanner planner, JLabel lbl) {

--- a/src/test/java/com/savingsplanner/ui/PanelParseTest.java
+++ b/src/test/java/com/savingsplanner/ui/PanelParseTest.java
@@ -1,0 +1,24 @@
+package com.savingsplanner.ui;
+
+import com.savingsplanner.service.PersistenceService;
+import com.savingsplanner.service.SavingsPlanner;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.text.NumberFormat;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class PanelParseTest {
+    @Test
+    void userPanelParsesPlainNumber() throws Exception {
+        SavingsPlanner planner = new SavingsPlanner();
+        UserPanel panel = new UserPanel(planner, new PersistenceService());
+        Method m = UserPanel.class.getDeclaredMethod("parseCell", Object.class, NumberFormat.class);
+        m.setAccessible(true);
+        NumberFormat fmt = NumberFormat.getCurrencyInstance(Locale.UK);
+        double val = (double) m.invoke(panel, "550.0", fmt);
+        assertEquals(550.0, val, 0.001);
+    }
+}


### PR DESCRIPTION
## Summary
- make table cell parsing accept plain numeric strings
- add regression test for `550.0` parsing in `UserPanel`

## Testing
- `mvn -q test` *(fails: Plugin could not be resolved – network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6844a5decb8c83229fe9cc7ecd243f6b