### PR TITLE
Add analysis options

### DIFF
--- a/src/main/java/com/savingsplanner/MainApp.java
+++ b/src/main/java/com/savingsplanner/MainApp.java
@@ -11,7 +11,7 @@ import com.savingsplanner.ui.UserPanel;
 import com.savingsplanner.ui.ExpensePanel;
 import com.savingsplanner.ui.GoalPanel;
 import com.savingsplanner.ui.GraphPanel;
-import com.savingsplanner.util.DialogUtil;
+import com.savingsplanner.ui.AnalysisDialog;
 import lombok.extern.log4j.Log4j2;
 
 import javax.swing.*;
@@ -108,15 +108,9 @@ public class MainApp {
             return;
         }
 
-        int months       = goal.months();
-        double income    = planner.calculateTotalIncome();
-        double expenses  = planner.calculateTotalExpenses();
-        double balance   = planner.calculateRemainingBalance();
-        double saved     = planner.calculateTotalSavingsForGoal();
+        int months = goal.months();
 
-        DialogUtil.showResultsDialog(
-                frame, goal, months, income, expenses, balance, saved
-        );
+        AnalysisDialog.showDialog(frame, planner, goal);
 
         GraphPanel chart = new GraphPanel(planner, goal, months);
         JDialog dlg = new JDialog(frame, "Savings Trajectory", true);

--- a/src/main/java/com/savingsplanner/ui/AnalysisDialog.java
+++ b/src/main/java/com/savingsplanner/ui/AnalysisDialog.java
@@ -1,0 +1,74 @@
+package com.savingsplanner.ui;
+
+import com.savingsplanner.model.SavingsGoal;
+import com.savingsplanner.service.SavingsPlanner;
+import com.savingsplanner.util.DialogUtil;
+import com.savingsplanner.util.PlanType;
+
+import javax.swing.*;
+import java.awt.*;
+
+/** Dialog showing savings analysis with selectable plans. */
+public class AnalysisDialog extends JDialog {
+
+    private final JTextArea textArea = new JTextArea();
+    private final SavingsPlanner planner;
+    private final SavingsGoal goal;
+
+    private AnalysisDialog(JFrame parent, SavingsPlanner planner, SavingsGoal goal) {
+        super(parent, "Savings Goal Analysis", true);
+        this.planner = planner;
+        this.goal = goal;
+        buildUI();
+        updateText(PlanType.REQUIRED);
+        pack();
+        setLocationRelativeTo(parent);
+        setVisible(true);
+    }
+
+    private void buildUI() {
+        setLayout(new BorderLayout(5,5));
+
+        JRadioButton req = new JRadioButton("Required for Goal");
+        JRadioButton max = new JRadioButton("Max Savings");
+        JRadioButton sug = new JRadioButton("50/30/20");
+        ButtonGroup group = new ButtonGroup();
+        group.add(req); group.add(max); group.add(sug);
+        req.setSelected(true);
+
+        JPanel options = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        options.add(req); options.add(max); options.add(sug);
+        add(options, BorderLayout.NORTH);
+
+        textArea.setEditable(false);
+        textArea.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 14));
+        JScrollPane scroll = new JScrollPane(textArea);
+        scroll.setPreferredSize(new Dimension(550, 400));
+        add(scroll, BorderLayout.CENTER);
+
+        JButton okBtn = new JButton("OK");
+        okBtn.addActionListener(e -> dispose());
+        JPanel south = new JPanel();
+        south.add(okBtn);
+        add(south, BorderLayout.SOUTH);
+
+        req.addActionListener(e -> updateText(PlanType.REQUIRED));
+        max.addActionListener(e -> updateText(PlanType.MAX));
+        sug.addActionListener(e -> updateText(PlanType.SUGGESTED));
+    }
+
+    private void updateText(PlanType type) {
+        double income = planner.calculateTotalIncome();
+        double expenses = planner.calculateTotalExpenses();
+        double balance = planner.calculateRemainingBalance();
+        double saved = planner.calculateTotalSavingsForGoal();
+        String text = DialogUtil.buildPlanAnalysisText(goal, goal.months(), income,
+                expenses, balance, saved, type);
+        textArea.setText(text);
+        textArea.setCaretPosition(0);
+    }
+
+    public static void showDialog(JFrame parent, SavingsPlanner planner, SavingsGoal goal) {
+        new AnalysisDialog(parent, planner, goal);
+    }
+}

--- a/src/main/java/com/savingsplanner/ui/ExpensePanel.java
+++ b/src/main/java/com/savingsplanner/ui/ExpensePanel.java
@@ -54,7 +54,9 @@ public class ExpensePanel extends JPanel {
                     String nm  = catObj.toString().trim();
                     double tot = parseCell(totObj);
                     // ensure the table stores a numeric value so it renders correctly
-                    table.setValueAt(tot, r, 1);
+                    if (!(totObj instanceof Number)) {
+                        table.setValueAt(tot, r, 1);
+                    }
                     planner.updateExpense(r, new BudgetCategory(nm, tot));
                     persistence.save(planner);
                     updateTotalLabel(planner, totalLabel);

--- a/src/main/java/com/savingsplanner/ui/ExpensePanel.java
+++ b/src/main/java/com/savingsplanner/ui/ExpensePanel.java
@@ -51,8 +51,10 @@ public class ExpensePanel extends JPanel {
                 Object catObj = table.getValueAt(r, 0);
                 Object totObj = table.getValueAt(r, 1);
                 try {
-                    String nm    = catObj.toString().trim();
-                    double tot   = parseCell(totObj);
+                    String nm  = catObj.toString().trim();
+                    double tot = parseCell(totObj);
+                    // ensure the table stores a numeric value so it renders correctly
+                    table.setValueAt(tot, r, 1);
                     planner.updateExpense(r, new BudgetCategory(nm, tot));
                     persistence.save(planner);
                     updateTotalLabel(planner, totalLabel);

--- a/src/main/java/com/savingsplanner/util/DialogUtil.java
+++ b/src/main/java/com/savingsplanner/util/DialogUtil.java
@@ -54,6 +54,12 @@ public final class DialogUtil {
         double goalTotal = goal.total();
         double remainingNeed = goalTotal - totalAlreadySaved;
 
+        if (remainingNeed <= 0) {
+            return String.format(
+                    "Savings Goal: \u201c%s\u201d (\u00A3%,.2f)%nGoal has already been reached!%n",
+                    goal.name(), goalTotal);
+        }
+
         StringBuilder sb = new StringBuilder();
         LocalDate today = LocalDate.now();
         DateTimeFormatter ukFmt = DateTimeFormatter.ofPattern("d MMMM yyyy");
@@ -122,7 +128,8 @@ public final class DialogUtil {
 
             double monthlyPlan = isAchievable ? requiredMonthly : remainingBalance;
             sb.append("\nSavings per UK tax year (starting 6 April 2025):\n");
-            sb.append(buildTaxYearSchedule(today, totalAlreadySaved, monthlyPlan, goal));
+            int monthsPlan = (int) Math.ceil(remainingNeed / monthlyPlan);
+            sb.append(buildTaxYearSchedule(today, totalAlreadySaved, monthlyPlan, goal, monthsPlan));
         }
 
         return sb.toString();
@@ -131,7 +138,8 @@ public final class DialogUtil {
     private static String buildTaxYearSchedule(LocalDate start,
                                                double startingSaved,
                                                double monthlySavings,
-                                               SavingsGoal goal) {
+                                               SavingsGoal goal,
+                                               int months) {
         record Info(double start, double added, double end) {}
 
         Map<String, Info> map = new LinkedHashMap<>();
@@ -140,7 +148,7 @@ public final class DialogUtil {
         double saved = startingSaved;
         double yearStartSaved = saved;
 
-        for (int m = 1; m <= goal.months(); m++) {
+        for (int m = 1; m <= months; m++) {
             saved = Math.min(goal.total(), saved + monthlySavings);
             current = start.plusMonths(m);
 
@@ -184,6 +192,12 @@ public final class DialogUtil {
 
         double goalTotal = goal.total();
         double remainingNeed = goalTotal - totalAlreadySaved;
+
+        if (remainingNeed <= 0) {
+            return String.format(
+                    "Savings Goal: \u201c%s\u201d (\u00A3%,.2f)%nGoal has already been reached!%n",
+                    goal.name(), goalTotal);
+        }
 
         double needs = totalIncome * 0.50;
         double wants = totalIncome * 0.30;
@@ -242,7 +256,8 @@ public final class DialogUtil {
         sb.append(String.format("Projected completion: %s%n%n", finish.format(ukFmt)));
 
         sb.append("Savings per UK tax year (starting 6 April 2025):\n");
-        sb.append(buildTaxYearSchedule(today, totalAlreadySaved, monthlyPlan, goal));
+        sb.append(buildTaxYearSchedule(
+                today, totalAlreadySaved, monthlyPlan, goal, monthsNeeded));
 
         return sb.toString();
     }

--- a/src/main/java/com/savingsplanner/util/DialogUtil.java
+++ b/src/main/java/com/savingsplanner/util/DialogUtil.java
@@ -185,6 +185,10 @@ public final class DialogUtil {
         double goalTotal = goal.total();
         double remainingNeed = goalTotal - totalAlreadySaved;
 
+        double needs = totalIncome * 0.50;
+        double wants = totalIncome * 0.30;
+        double savings = totalIncome * 0.20;
+
         double monthlyPlan;
         String label;
         switch (type) {
@@ -197,7 +201,7 @@ public final class DialogUtil {
                 label = "Maximum Savings";
             }
             case SUGGESTED -> {
-                monthlyPlan = totalIncome * 0.20;
+                monthlyPlan = savings;
                 label = "50/30/20 Suggestion (ignores expenses)";
             }
             default -> {
@@ -215,8 +219,14 @@ public final class DialogUtil {
         sb.append("Date run: ").append(today.format(ukFmt)).append("\n\n");
 
         sb.append(String.format("Total income: £%,.2f%n", totalIncome));
-        sb.append(String.format("Total expenses: £%,.2f%n", totalExpenses));
-        sb.append(String.format("Remaining balance: £%,.2f%n", remainingBalance));
+        if (type == PlanType.SUGGESTED) {
+            sb.append(String.format("Total expenses (50%%): £%,.2f%n", needs));
+            sb.append(String.format("Wants (30%%): £%,.2f%n", wants));
+            sb.append(String.format("Savings (20%%): £%,.2f%n", savings));
+        } else {
+            sb.append(String.format("Total expenses: £%,.2f%n", totalExpenses));
+            sb.append(String.format("Remaining balance: £%,.2f%n", remainingBalance));
+        }
         sb.append(String.format("Already saved: £%,.2f%n%n", totalAlreadySaved));
 
         sb.append(String.format("Monthly contribution: £%,.2f%n", monthlyPlan));

--- a/src/main/java/com/savingsplanner/util/DialogUtil.java
+++ b/src/main/java/com/savingsplanner/util/DialogUtil.java
@@ -69,7 +69,7 @@ public final class DialogUtil {
         double needs = totalIncome * 0.50;
         double wants = totalIncome * 0.30;
         double savings = totalIncome * 0.20;
-        sb.append("4) 50/30/20 rule suggestion:\n");
+        sb.append("4) 50/30/20 rule suggestion (ignores expenses):\n");
         sb.append(String.format("   • Needs (50%%): £%,.2f%n", needs));
         sb.append(String.format("   • Wants (30%%): £%,.2f%n", wants));
         sb.append(String.format("   • Savings (20%%): £%,.2f%n%n", savings));
@@ -198,7 +198,7 @@ public final class DialogUtil {
             }
             case SUGGESTED -> {
                 monthlyPlan = totalIncome * 0.20;
-                label = "50/30/20 Suggestion";
+                label = "50/30/20 Suggestion (ignores expenses)";
             }
             default -> {
                 monthlyPlan = 0;

--- a/src/main/java/com/savingsplanner/util/PlanType.java
+++ b/src/main/java/com/savingsplanner/util/PlanType.java
@@ -1,0 +1,11 @@
+package com.savingsplanner.util;
+
+/** Plan options for savings analysis. */
+public enum PlanType {
+    /** Required monthly contribution to meet the goal's deadline. */
+    REQUIRED,
+    /** Maximum possible monthly savings based on current balance. */
+    MAX,
+    /** 50/30/20 suggested monthly savings (20% of income). */
+    SUGGESTED
+}


### PR DESCRIPTION
## Summary
- add `PlanType` enum for analysis modes
- extend `DialogUtil` with `buildPlanAnalysisText`
- implement `AnalysisDialog` with radio buttons to show savings plans
- integrate the new dialog in `MainApp` before plotting graphs

## Testing
- `apt-get update`
- `apt-get install -y maven`
- `mvn -q -DskipTests=false test` *(fails: Could not transfer artifact from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_6845a28c46608322aa5159706bb1cda5