### PR TITLE
Increase analysis dialog size

### DIFF
--- a/src/main/java/com/savingsplanner/ui/AnalysisDialog.java
+++ b/src/main/java/com/savingsplanner/ui/AnalysisDialog.java
@@ -43,7 +43,7 @@ public class AnalysisDialog extends JDialog {
         textArea.setEditable(false);
         textArea.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 14));
         JScrollPane scroll = new JScrollPane(textArea);
-        scroll.setPreferredSize(new Dimension(550, 400));
+        scroll.setPreferredSize(new Dimension(550, 500));
         add(scroll, BorderLayout.CENTER);
 
         JButton okBtn = new JButton("OK");


### PR DESCRIPTION
## Summary
- make the analysis dialog taller so text for the 50/30/20 plan isn't clipped

## Testing
- `mvn -q test` *(fails: PluginResolutionException due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6845af8292ec832293152eead5b4d453