### PR TITLE
Add goal templates and breakdown

### DIFF
--- a/savings_data.json
+++ b/savings_data.json
@@ -2,7 +2,7 @@
   "users" : [ {
     "name" : "Josh",
     "income" : 6800.0,
-    "currentSavings" : 0.0
+    "currentSavings" : 25000.0
   } ],
   "expenses" : [ {
     "name" : "Rent",
@@ -15,10 +15,10 @@
     "total" : 350.0
   }, {
     "name" : "Subscriptions",
-    "total" : 100.0
+    "total" : 110.0
   }, {
     "name" : "Internet & Mobile",
-    "total" : 80.0
+    "total" : 100.0
   }, {
     "name" : "Transport",
     "total" : 150.0

--- a/src/main/java/com/savingsplanner/model/GoalTemplate.java
+++ b/src/main/java/com/savingsplanner/model/GoalTemplate.java
@@ -39,8 +39,25 @@ public enum GoalTemplate {
         return label;
     }
 
+    /**
+     * @return the sum of the template breakdown values. For the house template
+     * this represents the additional costs excluding any deposit.
+     */
     public double total() {
         return total;
+    }
+
+    /**
+     * Adjust the user supplied goal total according to this template. For
+     * {@link #HOUSE} the additional costs are added to the provided total
+     * (assumed to be the deposit). For other templates the amount is returned
+     * unchanged.
+     */
+    public double adjustTotal(double userTotal) {
+        if (this == HOUSE) {
+            return userTotal + total;
+        }
+        return userTotal;
     }
 
     public Map<String, Double> getBreakdown() {
@@ -64,11 +81,19 @@ public enum GoalTemplate {
      */
     public String buildBreakdownText() {
         StringBuilder sb = new StringBuilder();
-        sb.append(label).append(" Cost Breakdown:\n");
+        if (this == HOUSE) {
+            sb.append(label).append(" Additional Costs Breakdown:\n");
+        } else {
+            sb.append("Average ").append(label).append(" Cost Breakdown:\n");
+        }
         for (Map.Entry<String, Double> e : breakdown.entrySet()) {
             sb.append(String.format(" - %s: £%,.2f%n", e.getKey(), e.getValue()));
         }
-        sb.append(String.format("Total: £%,.2f%n", total));
+        if (this == HOUSE) {
+            sb.append(String.format("Total Extras: £%,.2f%n", total));
+        } else {
+            sb.append(String.format("Total: £%,.2f%n", total));
+        }
         return sb.toString();
     }
 }

--- a/src/main/java/com/savingsplanner/model/GoalTemplate.java
+++ b/src/main/java/com/savingsplanner/model/GoalTemplate.java
@@ -67,12 +67,11 @@ public enum GoalTemplate {
     }
 
     /**
-     * Get the total adjusted for the template if the goal name matches a template.
+     * Get the total adjusted for the template. Since template costs are now
+     * applied when a goal is saved, this simply returns {@code goal.total()}.
      */
     public static double adjustedTotalFor(SavingsGoal goal) {
-        return fromName(goal.name())
-                .map(t -> t.adjustTotal(goal.total()))
-                .orElse(goal.total());
+        return goal.total();
     }
 
     /**

--- a/src/main/java/com/savingsplanner/model/GoalTemplate.java
+++ b/src/main/java/com/savingsplanner/model/GoalTemplate.java
@@ -4,6 +4,8 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import com.savingsplanner.model.SavingsGoal;
+
 /**
  * Pre-defined savings goal templates with typical cost breakdowns.
  */
@@ -62,6 +64,15 @@ public enum GoalTemplate {
 
     public Map<String, Double> getBreakdown() {
         return Map.copyOf(breakdown);
+    }
+
+    /**
+     * Get the total adjusted for the template if the goal name matches a template.
+     */
+    public static double adjustedTotalFor(SavingsGoal goal) {
+        return fromName(goal.name())
+                .map(t -> t.adjustTotal(goal.total()))
+                .orElse(goal.total());
     }
 
     /**

--- a/src/main/java/com/savingsplanner/model/GoalTemplate.java
+++ b/src/main/java/com/savingsplanner/model/GoalTemplate.java
@@ -1,0 +1,74 @@
+package com.savingsplanner.model;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Pre-defined savings goal templates with typical cost breakdowns.
+ */
+public enum GoalTemplate {
+    WEDDING("Wedding", new LinkedHashMap<>() {{
+        put("Venue", 8000d);
+        put("Catering", 5000d);
+        put("Photography", 2000d);
+        put("Dress & Attire", 1500d);
+        put("Miscellaneous", 1500d);
+    }}),
+    HOUSE("House", new LinkedHashMap<>() {{
+        put("Stamp Duty", 4000d);
+        put("Legal Fees", 1500d);
+        put("Survey", 600d);
+        put("Moving Costs", 1200d);
+        put("Furnishings", 3000d);
+    }});
+
+    private final String label;
+    private final Map<String, Double> breakdown;
+    private final double total;
+
+    GoalTemplate(String label, Map<String, Double> breakdown) {
+        this.label = label;
+        this.breakdown = new LinkedHashMap<>(breakdown);
+        double sum = 0;
+        for (double v : breakdown.values()) sum += v;
+        this.total = sum;
+    }
+
+    public String label() {
+        return label;
+    }
+
+    public double total() {
+        return total;
+    }
+
+    public Map<String, Double> getBreakdown() {
+        return Map.copyOf(breakdown);
+    }
+
+    /**
+     * Lookup a template by name ignoring case.
+     */
+    public static Optional<GoalTemplate> fromName(String name) {
+        for (GoalTemplate t : values()) {
+            if (t.label.equalsIgnoreCase(name)) {
+                return Optional.of(t);
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Build a formatted text block describing the template breakdown.
+     */
+    public String buildBreakdownText() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(label).append(" Cost Breakdown:\n");
+        for (Map.Entry<String, Double> e : breakdown.entrySet()) {
+            sb.append(String.format(" - %s: £%,.2f%n", e.getKey(), e.getValue()));
+        }
+        sb.append(String.format("Total: £%,.2f%n", total));
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/savingsplanner/service/SavingsPlanner.java
+++ b/src/main/java/com/savingsplanner/service/SavingsPlanner.java
@@ -2,6 +2,7 @@ package com.savingsplanner.service;
 
 import com.savingsplanner.model.BudgetCategory;
 import com.savingsplanner.model.SavingsGoal;
+import com.savingsplanner.model.GoalTemplate;
 import com.savingsplanner.model.User;
 
 import java.io.Serializable;
@@ -89,7 +90,8 @@ public class SavingsPlanner implements Serializable {
     }
 
     public double calculateMonthlySavingsRequired(SavingsGoal goal) {
-        double remaining = goal.total() - calculateTotalSavingsForGoal();
+        double adjusted = GoalTemplate.adjustedTotalFor(goal);
+        double remaining = adjusted - calculateTotalSavingsForGoal();
         return remaining / goal.months();
     }
 

--- a/src/main/java/com/savingsplanner/ui/AnalysisDialog.java
+++ b/src/main/java/com/savingsplanner/ui/AnalysisDialog.java
@@ -1,6 +1,7 @@
 package com.savingsplanner.ui;
 
 import com.savingsplanner.model.SavingsGoal;
+import com.savingsplanner.model.GoalTemplate;
 import com.savingsplanner.service.SavingsPlanner;
 import com.savingsplanner.util.DialogUtil;
 import com.savingsplanner.util.PlanType;
@@ -62,9 +63,12 @@ public class AnalysisDialog extends JDialog {
         double expenses = planner.calculateTotalExpenses();
         double balance = planner.calculateRemainingBalance();
         double saved = planner.calculateTotalSavingsForGoal();
-        String text = DialogUtil.buildPlanAnalysisText(goal, goal.months(), income,
-                expenses, balance, saved, type);
-        textArea.setText(text);
+        StringBuilder sb = new StringBuilder();
+        GoalTemplate.fromName(goal.name())
+                .ifPresent(t -> sb.append(t.buildBreakdownText()).append("\n"));
+        sb.append(DialogUtil.buildPlanAnalysisText(goal, goal.months(), income,
+                expenses, balance, saved, type));
+        textArea.setText(sb.toString());
         textArea.setCaretPosition(0);
     }
 

--- a/src/main/java/com/savingsplanner/ui/AnalysisDialog.java
+++ b/src/main/java/com/savingsplanner/ui/AnalysisDialog.java
@@ -19,7 +19,7 @@ public class AnalysisDialog extends JDialog {
     private final SavingsGoal goal;
 
     private AnalysisDialog(JFrame parent, SavingsPlanner planner, SavingsGoal goal) {
-        super(parent, "Savings Goal Analysis", true);
+        scroll.setPreferredSize(new Dimension(650, 550));
         this.planner = planner;
         this.goal = goal;
         buildUI();

--- a/src/main/java/com/savingsplanner/ui/AnalysisDialog.java
+++ b/src/main/java/com/savingsplanner/ui/AnalysisDialog.java
@@ -63,12 +63,30 @@ public class AnalysisDialog extends JDialog {
         double expenses = planner.calculateTotalExpenses();
         double balance = planner.calculateRemainingBalance();
         double saved = planner.calculateTotalSavingsForGoal();
-        StringBuilder sb = new StringBuilder();
-        GoalTemplate.fromName(goal.name())
-                .ifPresent(t -> sb.append(t.buildBreakdownText()).append("\n"));
-        sb.append(DialogUtil.buildPlanAnalysisText(goal, goal.months(), income,
-                expenses, balance, saved, type));
-        textArea.setText(sb.toString());
+        String text = DialogUtil.buildPlanAnalysisText(goal, goal.months(), income,
+                expenses, balance, saved, type);
+
+        GoalTemplate.fromName(goal.name()).ifPresent(t -> {
+            String breakdown = t.buildBreakdownText();
+            if (t == GoalTemplate.HOUSE) {
+                int idx = text.indexOf("Total expenses");
+                if (idx >= 0) {
+                    int end = text.indexOf('\n', idx);
+                    if (end >= 0) {
+                        text = text.substring(0, end + 1) + breakdown +
+                                text.substring(end + 1);
+                    } else {
+                        text = text + "\n" + breakdown;
+                    }
+                } else {
+                    text = text + "\n" + breakdown;
+                }
+            } else {
+                text = text + "\n" + breakdown;
+            }
+        });
+
+        textArea.setText(text);
         textArea.setCaretPosition(0);
     }
 

--- a/src/main/java/com/savingsplanner/ui/AnalysisDialog.java
+++ b/src/main/java/com/savingsplanner/ui/AnalysisDialog.java
@@ -1,7 +1,7 @@
 package com.savingsplanner.ui;
 
-import com.savingsplanner.model.SavingsGoal;
 import com.savingsplanner.model.GoalTemplate;
+import com.savingsplanner.model.SavingsGoal;
 import com.savingsplanner.service.SavingsPlanner;
 import com.savingsplanner.util.DialogUtil;
 import com.savingsplanner.util.PlanType;
@@ -9,7 +9,9 @@ import com.savingsplanner.util.PlanType;
 import javax.swing.*;
 import java.awt.*;
 
-/** Dialog showing savings analysis with selectable plans. */
+/**
+ * Dialog showing savings analysis with selectable plans.
+ */
 public class AnalysisDialog extends JDialog {
 
     private final JTextArea textArea = new JTextArea();
@@ -28,17 +30,21 @@ public class AnalysisDialog extends JDialog {
     }
 
     private void buildUI() {
-        setLayout(new BorderLayout(5,5));
+        setLayout(new BorderLayout(5, 5));
 
         JRadioButton req = new JRadioButton("Required for Goal");
         JRadioButton max = new JRadioButton("Max Savings");
         JRadioButton sug = new JRadioButton("50/30/20");
         ButtonGroup group = new ButtonGroup();
-        group.add(req); group.add(max); group.add(sug);
+        group.add(req);
+        group.add(max);
+        group.add(sug);
         req.setSelected(true);
 
         JPanel options = new JPanel(new FlowLayout(FlowLayout.LEFT));
-        options.add(req); options.add(max); options.add(sug);
+        options.add(req);
+        options.add(max);
+        options.add(sug);
         add(options, BorderLayout.NORTH);
 
         textArea.setEditable(false);
@@ -63,30 +69,30 @@ public class AnalysisDialog extends JDialog {
         double expenses = planner.calculateTotalExpenses();
         double balance = planner.calculateRemainingBalance();
         double saved = planner.calculateTotalSavingsForGoal();
-        String text = DialogUtil.buildPlanAnalysisText(goal, goal.months(), income,
-                expenses, balance, saved, type);
+        final String[] text = {DialogUtil.buildPlanAnalysisText(goal, goal.months(), income,
+                expenses, balance, saved, type)};
 
         GoalTemplate.fromName(goal.name()).ifPresent(t -> {
             String breakdown = t.buildBreakdownText();
             if (t == GoalTemplate.HOUSE) {
-                int idx = text.indexOf("Total expenses");
+                int idx = text[0].indexOf("Total expenses");
                 if (idx >= 0) {
-                    int end = text.indexOf('\n', idx);
+                    int end = text[0].indexOf('\n', idx);
                     if (end >= 0) {
-                        text = text.substring(0, end + 1) + breakdown +
-                                text.substring(end + 1);
+                        text[0] = text[0].substring(0, end + 1) + breakdown +
+                                text[0].substring(end + 1);
                     } else {
-                        text = text + "\n" + breakdown;
+                        text[0] = text[0] + "\n" + breakdown;
                     }
                 } else {
-                    text = text + "\n" + breakdown;
+                    text[0] = text[0] + "\n" + breakdown;
                 }
             } else {
-                text = text + "\n" + breakdown;
+                text[0] = text[0] + "\n" + breakdown;
             }
         });
 
-        textArea.setText(text);
+        textArea.setText(text[0]);
         textArea.setCaretPosition(0);
     }
 

--- a/src/main/java/com/savingsplanner/ui/ExpensePanel.java
+++ b/src/main/java/com/savingsplanner/ui/ExpensePanel.java
@@ -31,7 +31,7 @@ public class ExpensePanel extends JPanel {
         JTable table = tablePanel.getTable();
 
         JPanel inputs = new JPanel(new GridLayout(2, 2, 5, 5));
-        JTextField nameField  = new JTextField();
+        JTextField nameField = new JTextField();
         JTextField totalField = new JTextField();
         inputs.add(new JLabel("Category:"));
         inputs.add(nameField);
@@ -51,7 +51,7 @@ public class ExpensePanel extends JPanel {
                 Object catObj = table.getValueAt(r, 0);
                 Object totObj = table.getValueAt(r, 1);
                 try {
-                    String nm  = catObj.toString().trim();
+                    String nm = catObj.toString().trim();
                     double tot = parseCell(totObj);
                     // ensure the table stores a numeric value so it renders correctly
                     if (!(totObj instanceof Number)) {
@@ -68,18 +68,19 @@ public class ExpensePanel extends JPanel {
             }
         });
 
-        JButton addBtn    = new JButton("Add Expense");
+        JButton addBtn = new JButton("Add Expense");
         JButton removeBtn = new JButton("Remove Selected");
 
         addBtn.addActionListener((ActionEvent e) -> {
             try {
-                String nm  = nameField.getText().trim();
-                double tot = Double.parseDouble(totalField.getText().trim());
+                String nm = nameField.getText().trim();
+                double tot = parseCell(totalField);
                 if (nm.isEmpty()) throw new IllegalArgumentException();
                 planner.addExpense(new BudgetCategory(nm, tot));
                 persistence.save(planner);
                 tablePanel.addRow(nm, tot);
-                nameField.setText(""); totalField.setText("");
+                nameField.setText("");
+                totalField.setText("");
                 updateTotalLabel(planner, totalLabel);
                 log.info("Added expense {} = {}", nm, tot);
             } catch (Exception ex) {

--- a/src/main/java/com/savingsplanner/ui/GoalPanel.java
+++ b/src/main/java/com/savingsplanner/ui/GoalPanel.java
@@ -126,10 +126,7 @@ public class GoalPanel extends JPanel {
             int    months = Integer.parseInt(monthsField.getText().trim());
             if (name.isEmpty() || months <= 0) throw new IllegalArgumentException();
 
-            Object sel = templateBox.getSelectedItem();
-            if (sel instanceof GoalTemplate t) {
-                total = t.adjustTotal(total);
-            }
+            // Template selection only fills the name; totals remain user-defined
 
             SavingsGoal g = new SavingsGoal(name, total, months);
             planner.setGoal(g);

--- a/src/main/java/com/savingsplanner/ui/GoalPanel.java
+++ b/src/main/java/com/savingsplanner/ui/GoalPanel.java
@@ -116,7 +116,6 @@ public class GoalPanel extends JPanel {
         Object sel = templateBox.getSelectedItem();
         if (sel instanceof GoalTemplate t) {
             nameField.setText(t.label());
-            totalField.setText(String.valueOf(t.total()));
         }
     }
 
@@ -126,6 +125,11 @@ public class GoalPanel extends JPanel {
             double total  = Double.parseDouble(totalField.getText().trim());
             int    months = Integer.parseInt(monthsField.getText().trim());
             if (name.isEmpty() || months <= 0) throw new IllegalArgumentException();
+
+            Object sel = templateBox.getSelectedItem();
+            if (sel instanceof GoalTemplate t) {
+                total = t.adjustTotal(total);
+            }
 
             SavingsGoal g = new SavingsGoal(name, total, months);
             planner.setGoal(g);

--- a/src/main/java/com/savingsplanner/ui/GoalPanel.java
+++ b/src/main/java/com/savingsplanner/ui/GoalPanel.java
@@ -126,7 +126,10 @@ public class GoalPanel extends JPanel {
             int    months = Integer.parseInt(monthsField.getText().trim());
             if (name.isEmpty() || months <= 0) throw new IllegalArgumentException();
 
-            // Template selection only fills the name; totals remain user-defined
+            Object sel = templateBox.getSelectedItem();
+            if (sel instanceof GoalTemplate t && t == GoalTemplate.HOUSE) {
+                total = t.adjustTotal(total);
+            }
 
             SavingsGoal g = new SavingsGoal(name, total, months);
             planner.setGoal(g);

--- a/src/main/java/com/savingsplanner/ui/GoalPanel.java
+++ b/src/main/java/com/savingsplanner/ui/GoalPanel.java
@@ -1,6 +1,7 @@
 package com.savingsplanner.ui;
 
 import com.savingsplanner.model.SavingsGoal;
+import com.savingsplanner.model.GoalTemplate;
 import com.savingsplanner.service.PersistenceService;
 import com.savingsplanner.service.SavingsPlanner;
 
@@ -21,6 +22,7 @@ public class GoalPanel extends JPanel {
     private final SavingsPlanner planner;
     private final PersistenceService persistence;
     private final JComboBox<SavingsGoal> selector = new JComboBox<>();
+    private final JComboBox<Object> templateBox = new JComboBox<>();
     private final JTextField nameField   = new JTextField();
     private final JTextField totalField  = new JTextField();
     private final JTextField monthsField = new JTextField();
@@ -66,7 +68,14 @@ public class GoalPanel extends JPanel {
         selector.addActionListener(e -> populateFields());
         left.add(selector, BorderLayout.NORTH);
 
-        JPanel inputs = new JPanel(new GridLayout(3,2,5,5));
+        JPanel inputs = new JPanel(new GridLayout(4,2,5,5));
+        templateBox.addItem("Custom");
+        for (GoalTemplate t : GoalTemplate.values()) {
+            templateBox.addItem(t);
+        }
+        templateBox.addActionListener(e -> applyTemplate());
+
+        inputs.add(new JLabel("Template:"));      inputs.add(templateBox);
         inputs.add(new JLabel("Goal Name:"));    inputs.add(nameField);
         inputs.add(new JLabel("Total (£):"));     inputs.add(totalField);
         inputs.add(new JLabel("Months:"));        inputs.add(monthsField);
@@ -100,6 +109,15 @@ public class GoalPanel extends JPanel {
         nameField  .setText(has ? g.name()   : "");
         totalField .setText(has ? String.valueOf(g.total())  : "");
         monthsField.setText(has ? String.valueOf(g.months()) : "");
+        templateBox.setSelectedIndex(0);
+    }
+
+    private void applyTemplate() {
+        Object sel = templateBox.getSelectedItem();
+        if (sel instanceof GoalTemplate t) {
+            nameField.setText(t.label());
+            totalField.setText(String.valueOf(t.total()));
+        }
     }
 
     private void onSaveGoal(ActionEvent e) {

--- a/src/main/java/com/savingsplanner/ui/GraphPanel.java
+++ b/src/main/java/com/savingsplanner/ui/GraphPanel.java
@@ -1,6 +1,7 @@
 package com.savingsplanner.ui;
 
 import com.savingsplanner.model.SavingsGoal;
+import com.savingsplanner.model.GoalTemplate;
 import com.savingsplanner.service.SavingsPlanner;
 import org.jfree.chart.ChartFactory;
 import org.jfree.chart.ChartPanel;
@@ -62,7 +63,7 @@ public class GraphPanel extends JPanel {
         double suggestedMonthly = planner.calculateSuggestedSavings(goal)[0];
         double maxMonthly = planner.calculateRemainingBalance();
         double twentyMonthly = planner.calculateTotalIncome() * 0.20;
-        double goalTotal = goal.total();
+        double goalTotal = GoalTemplate.adjustedTotalFor(goal);
 
         double remainingNeed = Math.max(0, goalTotal - startSaved);
         int monthsMaxNeeded = maxMonthly > 0 ? (int) Math.ceil(remainingNeed / maxMonthly) : 0;

--- a/src/main/java/com/savingsplanner/ui/UserPanel.java
+++ b/src/main/java/com/savingsplanner/ui/UserPanel.java
@@ -78,6 +78,8 @@ public class UserPanel extends JPanel {
                     double inc = parseCell(incomeObj, fmt);
                     double sav = parseCell(savedObj, fmt);
                     planner.updateUser(row, new User(nm, inc, sav));
+                    table.setValueAt(inc, row, 1);
+                    table.setValueAt(sav, row, 2);
                     persistence.save(planner);
                     updateTotalLabel(planner, totalLabel);
                     log.info("Updated user {}", nm);

--- a/src/main/java/com/savingsplanner/util/DialogUtil.java
+++ b/src/main/java/com/savingsplanner/util/DialogUtil.java
@@ -1,6 +1,7 @@
 package com.savingsplanner.util;
 
 import com.savingsplanner.model.SavingsGoal;
+import com.savingsplanner.model.GoalTemplate;
 import com.savingsplanner.util.PlanType;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -51,7 +52,7 @@ public final class DialogUtil {
                                             double remainingBalance,
                                             double totalAlreadySaved) {
 
-        double goalTotal = goal.total();
+        double goalTotal = GoalTemplate.adjustedTotalFor(goal);
         double remainingNeed = goalTotal - totalAlreadySaved;
 
         if (remainingNeed <= 0) {
@@ -148,8 +149,9 @@ public final class DialogUtil {
         double saved = startingSaved;
         double yearStartSaved = saved;
 
+        double goalTotalLimit = GoalTemplate.adjustedTotalFor(goal);
         for (int m = 1; m <= months; m++) {
-            saved = Math.min(goal.total(), saved + monthlySavings);
+            saved = Math.min(goalTotalLimit, saved + monthlySavings);
             current = start.plusMonths(m);
 
             while (!current.isBefore(taxYearStart.plusYears(1))) {
@@ -190,7 +192,7 @@ public final class DialogUtil {
                                                double totalAlreadySaved,
                                                PlanType type) {
 
-        double goalTotal = goal.total();
+        double goalTotal = GoalTemplate.adjustedTotalFor(goal);
         double remainingNeed = goalTotal - totalAlreadySaved;
 
         if (remainingNeed <= 0) {

--- a/src/main/java/com/savingsplanner/util/DialogUtil.java
+++ b/src/main/java/com/savingsplanner/util/DialogUtil.java
@@ -248,6 +248,12 @@ public final class DialogUtil {
             sb.append("\nNo funds available with this plan.\n");
             return sb.toString();
         }
+        if (type == PlanType.REQUIRED && monthlyPlan > remainingBalance) {
+            sb.append(String.format(
+                    "Required contribution exceeds available funds of £%,.2f. Goal cannot be met.%n",
+                    remainingBalance));
+            return sb.toString();
+        }
 
         int monthsNeeded = (int) Math.ceil(remainingNeed / monthlyPlan);
         LocalDate finish = today.plusMonths(monthsNeeded);

--- a/src/test/java/com/savingsplanner/model/GoalTemplateTest.java
+++ b/src/test/java/com/savingsplanner/model/GoalTemplateTest.java
@@ -7,9 +7,8 @@ import static org.junit.jupiter.api.Assertions.*;
 class GoalTemplateTest {
 
     @Test
-    void adjustedTotalAddsHouseExtras() {
-        SavingsGoal goal = new SavingsGoal("House", 20000.0, 12);
-        double adjusted = GoalTemplate.adjustedTotalFor(goal);
+    void adjustTotalAddsHouseExtras() {
+        double adjusted = GoalTemplate.HOUSE.adjustTotal(20000.0);
         assertEquals(30300.0, adjusted, 0.001);
     }
 

--- a/src/test/java/com/savingsplanner/model/GoalTemplateTest.java
+++ b/src/test/java/com/savingsplanner/model/GoalTemplateTest.java
@@ -1,0 +1,32 @@
+package com.savingsplanner.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GoalTemplateTest {
+
+    @Test
+    void adjustedTotalAddsHouseExtras() {
+        SavingsGoal goal = new SavingsGoal("House", 20000.0, 12);
+        double adjusted = GoalTemplate.adjustedTotalFor(goal);
+        assertEquals(30300.0, adjusted, 0.001);
+    }
+
+    @Test
+    void breakdownTextContainsLabels() {
+        String text = GoalTemplate.WEDDING.buildBreakdownText();
+        assertTrue(text.contains("Average Wedding Cost Breakdown"));
+        assertTrue(text.contains("Total: £18,000.00"));
+
+        text = GoalTemplate.HOUSE.buildBreakdownText();
+        assertTrue(text.contains("House Additional Costs Breakdown"));
+        assertTrue(text.contains("Total Extras: £10,300.00"));
+    }
+
+    @Test
+    void fromNameIsCaseInsensitive() {
+        assertTrue(GoalTemplate.fromName("wedding").isPresent());
+        assertEquals(GoalTemplate.HOUSE, GoalTemplate.fromName("HOUSE").orElseThrow());
+    }
+}

--- a/src/test/java/com/savingsplanner/util/DialogUtilTest.java
+++ b/src/test/java/com/savingsplanner/util/DialogUtilTest.java
@@ -1,0 +1,31 @@
+package com.savingsplanner.util;
+
+import com.savingsplanner.model.SavingsGoal;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DialogUtilTest {
+
+    @Test
+    void requiredPlanWarnsWhenUnachievable() {
+        SavingsGoal goal = new SavingsGoal("Car", 5000.0, 1);
+        String text = DialogUtil.buildPlanAnalysisText(goal, 1,
+                2000.0, 1000.0, 1000.0, 0.0, PlanType.REQUIRED);
+        assertTrue(text.contains("Required contribution exceeds"));
+    }
+
+    @Test
+    void taxYearScheduleSpansMultipleYears() throws Exception {
+        var m = DialogUtil.class.getDeclaredMethod(
+                "buildTaxYearSchedule",
+                java.time.LocalDate.class, double.class, double.class,
+                com.savingsplanner.model.SavingsGoal.class, int.class);
+        m.setAccessible(true);
+        String schedule = (String) m.invoke(null,
+                java.time.LocalDate.of(2025,1,1), 0.0, 1000.0,
+                new com.savingsplanner.model.SavingsGoal("Goal", 5000.0, 10), 16);
+        assertTrue(schedule.contains("2025/2026"));
+        assertTrue(schedule.contains("2026/2027"));
+    }
+}


### PR DESCRIPTION
## Summary
- add `GoalTemplate` enum for common savings goals
- support template selection when editing goals
- show template breakdown in analysis dialog

## Testing
- `mvn test` *(fails: Plugin could not be resolved due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6845b18173d483228932ba1e50619b5a