### PR TITLE
Add adjustable split for 50/30/20 analysis

### DIFF
--- a/src/main/java/com/savingsplanner/ui/AnalysisDialog.java
+++ b/src/main/java/com/savingsplanner/ui/AnalysisDialog.java
@@ -14,6 +14,8 @@ public class AnalysisDialog extends JDialog {
     private final JTextArea textArea = new JTextArea();
     private final SavingsPlanner planner;
     private final SavingsGoal goal;
+    private final JSlider splitSlider = new JSlider(0, 50, 20);
+    private final JLabel splitLabel = new JLabel();
 
     private AnalysisDialog(JFrame parent, SavingsPlanner planner, SavingsGoal goal) {
         super(parent, "Savings Goal Analysis", true);
@@ -40,6 +42,23 @@ public class AnalysisDialog extends JDialog {
         options.add(req); options.add(max); options.add(sug);
         add(options, BorderLayout.NORTH);
 
+        splitSlider.setMajorTickSpacing(10);
+        splitSlider.setMinorTickSpacing(1);
+        splitSlider.setPaintTicks(true);
+        splitSlider.addChangeListener(e -> {
+            splitLabel.setText("Savings " + splitSlider.getValue() + "% / Wants "
+                    + (50 - splitSlider.getValue()) + "%");
+            if (sug.isSelected()) updateText(PlanType.SUGGESTED);
+        });
+        splitLabel.setText("Savings 20% / Wants 30%");
+        splitLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        splitSlider.setEnabled(false);
+        JPanel sliderPanel = new JPanel();
+        sliderPanel.setLayout(new BoxLayout(sliderPanel, BoxLayout.Y_AXIS));
+        sliderPanel.add(splitLabel);
+        sliderPanel.add(splitSlider);
+        add(sliderPanel, BorderLayout.WEST);
+
         textArea.setEditable(false);
         textArea.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 14));
         JScrollPane scroll = new JScrollPane(textArea);
@@ -52,9 +71,9 @@ public class AnalysisDialog extends JDialog {
         south.add(okBtn);
         add(south, BorderLayout.SOUTH);
 
-        req.addActionListener(e -> updateText(PlanType.REQUIRED));
-        max.addActionListener(e -> updateText(PlanType.MAX));
-        sug.addActionListener(e -> updateText(PlanType.SUGGESTED));
+        req.addActionListener(e -> {splitSlider.setEnabled(false); updateText(PlanType.REQUIRED);});
+        max.addActionListener(e -> {splitSlider.setEnabled(false); updateText(PlanType.MAX);});
+        sug.addActionListener(e -> {splitSlider.setEnabled(true); updateText(PlanType.SUGGESTED);});
     }
 
     private void updateText(PlanType type) {
@@ -62,8 +81,9 @@ public class AnalysisDialog extends JDialog {
         double expenses = planner.calculateTotalExpenses();
         double balance = planner.calculateRemainingBalance();
         double saved = planner.calculateTotalSavingsForGoal();
+        int savingsPct = splitSlider.getValue();
         String text = DialogUtil.buildPlanAnalysisText(goal, goal.months(), income,
-                expenses, balance, saved, type);
+                expenses, balance, saved, type, savingsPct / 100.0);
         textArea.setText(text);
         textArea.setCaretPosition(0);
     }

--- a/src/main/java/com/savingsplanner/util/DialogUtil.java
+++ b/src/main/java/com/savingsplanner/util/DialogUtil.java
@@ -188,7 +188,8 @@ public final class DialogUtil {
                                                double totalExpenses,
                                                double remainingBalance,
                                                double totalAlreadySaved,
-                                               PlanType type) {
+                                               PlanType type,
+                                               double savingsFraction) {
 
         double goalTotal = goal.total();
         double remainingNeed = goalTotal - totalAlreadySaved;
@@ -216,7 +217,8 @@ public final class DialogUtil {
             }
             case SUGGESTED -> {
                 monthlyPlan = savings;
-                label = "50/30/20 Suggestion (ignores expenses)";
+                label = String.format("50/%.0f/%.0f Suggestion (ignores expenses)",
+                        (50 - savingsFraction * 100), savingsFraction * 100);
             }
             default -> {
                 monthlyPlan = 0;
@@ -235,8 +237,8 @@ public final class DialogUtil {
         sb.append(String.format("Total income: £%,.2f%n", totalIncome));
         if (type == PlanType.SUGGESTED) {
             sb.append(String.format("Total expenses (50%%): £%,.2f%n", needs));
-            sb.append(String.format("Wants (30%%): £%,.2f%n", wants));
-            sb.append(String.format("Savings (20%%): £%,.2f%n", savings));
+            sb.append(String.format("Wants (%.0f%%): £%,.2f%n", (50 - savingsFraction * 100), wants));
+            sb.append(String.format("Savings (%.0f%%): £%,.2f%n", savingsFraction * 100, savings));
         } else {
             sb.append(String.format("Total expenses: £%,.2f%n", totalExpenses));
             sb.append(String.format("Remaining balance: £%,.2f%n", remainingBalance));

--- a/src/main/java/com/savingsplanner/util/DialogUtil.java
+++ b/src/main/java/com/savingsplanner/util/DialogUtil.java
@@ -201,8 +201,8 @@ public final class DialogUtil {
         }
 
         double needs = totalIncome * 0.50;
-        double wants = totalIncome * 0.30;
-        double savings = totalIncome * 0.20;
+        double wants = totalIncome * (0.50 - savingsFraction);
+        double savings = totalIncome * savingsFraction;
 
         double monthlyPlan;
         String label;

--- a/src/main/java/com/savingsplanner/util/PlanType.java
+++ b/src/main/java/com/savingsplanner/util/PlanType.java
@@ -6,6 +6,6 @@ public enum PlanType {
     REQUIRED,
     /** Maximum possible monthly savings based on current balance. */
     MAX,
-    /** 50/30/20 suggested monthly savings (20% of income). */
+    /** 50/30/20 style suggestion (adjustable savings percent). */
     SUGGESTED
 }


### PR DESCRIPTION
## Summary
- add slider to adjust the 30/20 split in the analysis dialog
- compute suggested plan values based on selected savings percentage
- keep existing analysis text constants intact

## Testing
- `mvn -q -DskipTests=true package` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_6845ced9c9308322bf25ca152ad52dec